### PR TITLE
Return error instead of panicking when encountering an unknown keyword

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,9 @@ quick_error! {
         ArgumentParseError(s: &'static str) {
             display("Argument parse error {}", s)
         }
+        UnknownKeywordError(s: String) {
+            display("Trying to parse unknown keyword '{}'", s)
+        }
         PlaceHolder {
             display("placeholder")
         }

--- a/src/substmt.rs
+++ b/src/substmt.rs
@@ -46,7 +46,7 @@ pub struct SubStmtUtil;
 impl SubStmtUtil {
     // Parse a single statement.
     pub fn call_stmt_parser(parser: &mut Parser, keyword: &str) -> Result<YangStmt, YangError> {
-        let f = STMT_PARSER.get(keyword).unwrap();
+        let f = STMT_PARSER.get(keyword).ok_or(YangError::UnknownKeywordError(String::from(keyword)))?;
         f(parser)
     }
 


### PR DESCRIPTION
When parsing a YANG file that contains vendor-specific keywords yang-rs doesn't know about, it currently panics.
With this change, it returns a sensible error instead.