### PR TITLE
Fix unknown keywords as first substatement

### DIFF
--- a/src/substmt.rs
+++ b/src/substmt.rs
@@ -46,8 +46,10 @@ pub struct SubStmtUtil;
 impl SubStmtUtil {
     // Parse a single statement.
     pub fn call_stmt_parser(parser: &mut Parser, keyword: &str) -> Result<YangStmt, YangError> {
-        let f = STMT_PARSER.get(keyword).unwrap();
-        f(parser)
+        match STMT_PARSER.get(keyword) {
+            Some(f) => f(parser),
+            None => UnknownStmt::parse(parser, keyword),
+        }
     }
 
     pub fn parse_substmts(


### PR DESCRIPTION
When an unknown keyword is the first substatement, the parser panics instead of handling it as an `UnknownStmt`