### PR TITLE
Fix parsing UnknownStmt with body without arg

### DIFF
--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -5550,11 +5550,11 @@ impl UnknownStmt {
         let token = parser.get_token()?;
         let arg = match token {
             Token::Identifier(s) | Token::QuotedString(s) => Some(s),
-            Token::StatementEnd => {
+            Token::StatementEnd | Token::BlockBegin => {
                 parser.save_token(token);
                 None
-            }
-            _ => return Err(YangError::UnexpectedToken(token.to_string())),
+            },
+            _ => return Err(YangError::UnexpectedToken(format!("{} after UnknownStmt", token.to_string()))),
         };
 
         let token = parser.get_token()?;


### PR DESCRIPTION
Currently, parsing unknown statements with a block of substatements but no arg fails, this fixes that.