### PR TITLE
Implement Cisco-NSO nonstandard parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ lazy_static = "1.4.0"
 quick-error = "2.0.1"
 derive-getters = "0.2.0"
 url = "2.2.2"
+
+[features]
+# Enables parsing some non-standard YANG constructs used in Cisco NSO
+cisco-nso-extensions = []

--- a/README.md
+++ b/README.md
@@ -29,3 +29,10 @@ match yang {
 }
 
 ```
+
+## Feature 'cisco-nso-extensions'
+
+Enables parsing a few nonstandard constructs Cisco allows and uses with Network Service Orchestrator (NSO):
+
+- Empty `input` / `output` statements
+- `deref` in `leafref` `path` substatements ([see RFC errata 5617](https://www.rfc-editor.org/errata/eid5617))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -432,7 +432,13 @@ impl Parser {
             while l.len() > 0 {
                 let c = l.chars().next().unwrap();
 
-                if c.is_whitespace() || c == '"' || c == '\'' || c == '}' || c == '{' || c == ';' {
+                if c.is_whitespace() || c == ';' || c == '}' || c == '{' {
+                    break;
+                }
+
+                // Cisco allows quote characters in unquoted strings :/
+                #[cfg(not(feature = "cisco-nso-extensions"))]
+                if c == '"' || c == '\'' {
                     break;
                 }
 

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -4827,7 +4827,14 @@ impl Stmt for InputStmt {
     }
 
     /// Return true if this statement has substatements.
+    #[cfg(not(feature = "cisco-nso-extensions"))]
     fn has_substmts() -> bool {
+        true
+    }
+
+    /// Return true if this statement has sub-statements optionally.
+    #[cfg(feature = "cisco-nso-extensions")]
+    fn opt_substmts() -> bool {
         true
     }
 
@@ -4838,6 +4845,19 @@ impl Stmt for InputStmt {
             SubStmtDef::ZeroOrMore(SubStmtWith::Selection(TypedefOrGrouping::keywords)),
             SubStmtDef::OneOrMore(SubStmtWith::Selection(DataDefStmt::keywords)),
         ]
+    }
+
+    /// Constructor with a single arg. Panic if it is not defined.
+    #[cfg(feature = "cisco-nso-extensions")]
+    fn new_with_arg(_arg: Self::Arg) -> YangStmt
+    where
+        Self: Sized,
+    {
+        YangStmt::InputStmt(InputStmt {
+            must: Vec::new(),
+            typedef_or_grouping: TypedefOrGrouping::new(),
+            data_def: DataDefStmt::new(),
+        })
     }
 
     /// Constructor with tuple of substatements. Panic if it is not defined.
@@ -4946,7 +4966,14 @@ impl Stmt for OutputStmt {
     }
 
     /// Return true if this statement has substatements.
+    #[cfg(not(feature = "cisco-nso-extensions"))]
     fn has_substmts() -> bool {
+        true
+    }
+
+    /// Return true if this statement has sub-statements optionally.
+    #[cfg(feature = "cisco-nso-extensions")]
+    fn opt_substmts() -> bool {
         true
     }
 
@@ -4957,6 +4984,19 @@ impl Stmt for OutputStmt {
             SubStmtDef::ZeroOrMore(SubStmtWith::Selection(TypedefOrGrouping::keywords)),
             SubStmtDef::OneOrMore(SubStmtWith::Selection(DataDefStmt::keywords)),
         ]
+    }
+
+    /// Constructor with a single arg. Panic if it is not defined.
+    #[cfg(feature = "cisco-nso-extensions")]
+    fn new_with_arg(_arg: Self::Arg) -> YangStmt
+    where
+        Self: Sized,
+    {
+        YangStmt::OutputStmt(OutputStmt {
+            must: Vec::new(),
+            typedef_or_grouping: TypedefOrGrouping::new(),
+            data_def: DataDefStmt::new(),
+        })
     }
 
     /// Constructor with tuple of substatements. Panic if it is not defined.


### PR DESCRIPTION
Cisco uses some YANG constructs that are not strictly compliant with RFC7950 in their YANG-Files describing Cisco's Network Service Operators built-in functionality,
most notably `input` and `output` statements without a body,
and using XPath `deref` in `leafref` paths.

This MR enables parsing these constructs when enabling a new crate feature `cisco-nso-extensions`.