### PR TITLE
Fix escaping in double quoted string

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -357,9 +357,7 @@ impl Parser {
             token = Token::StatementEnd;
         } else if input.starts_with('"') {
             let mut original = &input[1..];
-
             let mut result = String::new();
-            result.reserve(original.len());
 
             let mut chars = original.chars();
             loop {


### PR DESCRIPTION
Issue: https://github.com/sjtakada/yang-rs/issues/21

Escaped characters are supposed to be replaced by their equivalent special character.

RFC 6.1.3:

> Within a double-quoted string (enclosed within " "), a backslash
>    character introduces a representation of a special character, which
>    depends on the character that immediately follows the backslash:
>
>     \n      newline
>     \t      a tab character
>     \"      a double quote
>     \\      a single backslash
>
> The backslash MUST NOT be followed by any other character.